### PR TITLE
Fix Patreon member count to exclude members with irregular tier names

### DIFF
--- a/patreon/member-shoutouts/src/main.rs
+++ b/patreon/member-shoutouts/src/main.rs
@@ -112,7 +112,16 @@ fn main() -> Result<()> {
         }
     }
 
-    println!("{}total: {} active members{}", dim(), members.len(), rst());
+    let total_recognized = members
+        .iter()
+        .filter(|m| TIERS.iter().any(|(tier, _)| m.tier.as_deref() == Some(tier)))
+        .count();
+    println!(
+        "{}total: {} active members{}",
+        dim(),
+        total_recognized,
+        rst()
+    );
     println!("{}patreon: {}{}{}{}", dim(), rst(), color256(6), LINK, rst());
 
     Ok(())


### PR DESCRIPTION
The total count now only includes members whose tier exactly matches one of the three recognized tiers (/usr/bin/env bash, /bin/bash, /bin/sh).

Previously, the total showed all active patrons while the tier subtotals only showed members with recognized tier names, causing the total to be greater than the sum of the subtotals.

This change ensures the total equals the sum of the three tier counts by filtering out members with irregular or unrecognized tier names from the total. PR reviewers may want to instead handle members with incorrect tier names differently (e.g., by updating tier names in the source data or displaying them separately).