### PR TITLE
No longer reflect user input in usage

### DIFF
--- a/code/2026-01-07-spinner/spinner
+++ b/code/2026-01-07-spinner/spinner
@@ -23,7 +23,7 @@ usage() {
 
 	Options
 	  -d          enable debug output
-	  -t <theme>  theme to use, default is $THEME
+	  -t <theme>  theme to use, default is default
 	  -h          print this message and exit
 	EOF
 }


### PR DESCRIPTION
`-t` argument was being reflected to the user if they supplied it and failed to provide a command to spinner.