### PR TITLE
Initialize old values to 0 at the beginning

### DIFF
--- a/code/2026-03-18-linux-network-vis/net
+++ b/code/2026-03-18-linux-network-vis/net
@@ -53,14 +53,15 @@ process-iface() {
 	# store the new data no matter what
 	DATA[$iface]="$rx_bytes $tx_bytes"
 
-	# stop here if we haven't seen this interface before
-	if [[ -z $old ]]; then
-		echo "> $iface old data not found"
-		return 1
-	fi
-
 	local old_rx_bytes old_tx_bytes
-	read -r old_rx_bytes old_tx_bytes <<< "$old"
+
+	# initialize old values to 0 if we haven't seen this interface before
+	if [[ -z $old ]]; then
+		old_rx_bytes=0
+		old_tx_bytes=0
+	else
+		read -r old_rx_bytes old_tx_bytes <<< "$old"
+	fi
 
 	local d_rx_bytes=$((rx_bytes - old_rx_bytes))
 	local d_tx_bytes=$((tx_bytes - old_tx_bytes))

--- a/code/2026-03-18-linux-network-vis/net
+++ b/code/2026-03-18-linux-network-vis/net
@@ -9,6 +9,7 @@
 #
 # # Contributors
 # - Dave Eddy <ysap@daveeddy.com>
+# - Ilias Moulas <ilias@moulas.dev>
 
 declare -A DATA=()
 


### PR DESCRIPTION
Hey, Dave. I wanted to make this PR to:

Initialize old data to 0 at the beginning of the net visualizer's execution, instead of returning with data not found message to make the formatting of colors and spacing consistent.

It just looks prettier to me. What do you think?