### PR TITLE
bad substitution error. Replace curly brackets {} with Parentheses ()

### DIFF
--- a/code/2026-03-18-linux-network-vis/net
+++ b/code/2026-03-18-linux-network-vis/net
@@ -72,9 +72,9 @@ process-iface() {
 	local d_tx_bits=$((d_tx_bytes * 8))
 	local d_total_bits=$((d_total_bytes * 8))
 
-	local rx=${ format-bits "$d_rx_bits"; }
-	local tx=${ format-bits "$d_tx_bits"; }
-	local total=${ format-bits "$d_total_bits"; }
+	local rx=$(format-bits "$d_rx_bits")
+	local tx=$(format-bits "$d_tx_bits")
+	local total=$(format-bits "$d_total_bits")
 
 	printf "$DATA_FMT" "$iface" "$rx" "$tx" "$total"
 }


### PR DESCRIPTION
Found 'net' would not work on 2 of my Linux machines with bash version 5.2.1 but found that on my 3rd machine that was running bash 5.3.0, it did work. Found there was a bad substitution error. To correct the issue I replaced the '${....;}' on lines 75-77 with '$(.....)'. This fix my issue with the machines running bash 5.2.1 and still worked on my other machine running bash 5.3.0